### PR TITLE
Provide Option (Default) to Send User/App-level Messages Back on WebSocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dvonthenen/enterprise-reference-implementation
 go 1.18
 
 require (
-	github.com/dvonthenen/symbl-go-sdk v0.1.4-0.20221221193649-83b596f18b25
+	github.com/dvonthenen/symbl-go-sdk v0.1.4-0.20221224023133-35e1f570ee05
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f
 	github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c
 	github.com/neo4j/neo4j-go-driver/v5 v5.3.0
@@ -31,10 +31,11 @@ require (
 
 replace (
 	github.com/gorilla/websocket => github.com/dvonthenen/websocket v1.5.1-0.20221123154619-09865dbf1be2
-	github.com/koding/websocketproxy => github.com/dvonthenen/websocketproxy v0.0.0-20221207172044-14b1fc90f46a
+	github.com/koding/websocketproxy => github.com/dvonthenen/websocketproxy v0.0.0-20221223221552-50864d1ca0d3
 	github.com/r3labs/sse/v2 => github.com/dvonthenen/sse/v2 v2.0.0-20221222171132-1daa5f8b774c
 )
 
-// replace github.com/gorilla/websocket => ../../dvonthenen/websocket
-// replace github.com/koding/websocketproxy => ../../koding/websocketproxy
-// replace github.com/r3labs/sse => ../../r3labs/sse
+// replace github.com/dvonthenen/symbl-go-sdk => ../../dvonthenen/symbl-go-sdk
+// replace github.com/dvonthenen/websocket => ../../dvonthenen/websocket
+// replace github.com/dvonthenen/websocketproxy => ../../koding/websocketproxy
+// replace github.com/dvonthenen/sse => ../../r3labs/sse

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,12 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dvonthenen/sse/v2 v2.0.0-20221222171132-1daa5f8b774c h1:eu91E8j21DyoIXJyC9dNC5hSK2yrkmPzvh0t6zwQts0=
 github.com/dvonthenen/sse/v2 v2.0.0-20221222171132-1daa5f8b774c/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
-github.com/dvonthenen/symbl-go-sdk v0.1.4-0.20221221193649-83b596f18b25 h1:JgxKs8XcbamDkLfpXrpcesitnf4qKflFYlp0WwWZDN0=
-github.com/dvonthenen/symbl-go-sdk v0.1.4-0.20221221193649-83b596f18b25/go.mod h1:RmbXjJ4rOws/ZoFgKvTmAZ6RNJHqP16bCrZ5Vtzjs7A=
+github.com/dvonthenen/symbl-go-sdk v0.1.4-0.20221224023133-35e1f570ee05 h1:sr4Y9MoRb7zqFbvL5o5kV6RT2cVltVpgZ/EnrAi5wWY=
+github.com/dvonthenen/symbl-go-sdk v0.1.4-0.20221224023133-35e1f570ee05/go.mod h1:Dw2W6FSawCqR01ebN4oJ3Y+/N8Yer88hBFkxrP9aZyw=
 github.com/dvonthenen/websocket v1.5.1-0.20221123154619-09865dbf1be2 h1:rsU8o6R7JTsP1c8WnXQhbaGRITJgL+SeDgc6zsFTfSU=
 github.com/dvonthenen/websocket v1.5.1-0.20221123154619-09865dbf1be2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/dvonthenen/websocketproxy v0.0.0-20221207172044-14b1fc90f46a h1:3OAj7dPSMcVqm7kan+pOPgyENNnvteqRQFeRgrEzhSE=
-github.com/dvonthenen/websocketproxy v0.0.0-20221207172044-14b1fc90f46a/go.mod h1:WJRZv/X/jzGIH75i4yqPuDIXRFAh06Vs6C6+AyX+j/Q=
+github.com/dvonthenen/websocketproxy v0.0.0-20221223221552-50864d1ca0d3 h1:+LIfWxCk4z4kZ4IQAYmxebFzAcDvNkibnj37qPXkqng=
+github.com/dvonthenen/websocketproxy v0.0.0-20221223221552-50864d1ca0d3/go.mod h1:WJRZv/X/jzGIH75i4yqPuDIXRFAh06Vs6C6+AyX+j/Q=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=

--- a/pkg/analyzer/handlers/trackerhandler.go
+++ b/pkg/analyzer/handlers/trackerhandler.go
@@ -13,6 +13,7 @@ import (
 
 	rabbitinterfaces "github.com/dvonthenen/enterprise-reference-implementation/pkg/analyzer/rabbit/interfaces"
 	interfaces "github.com/dvonthenen/enterprise-reference-implementation/pkg/interfaces"
+	sdkinterfaces "github.com/dvonthenen/symbl-go-sdk/pkg/api/streaming/v1/interfaces"
 )
 
 func NewTrackerHandler(options HandlerOptions) *rabbitinterfaces.RabbitMessageHandler {
@@ -83,8 +84,9 @@ func (ch TrackerHandler) ProcessMessage(byData []byte) error {
 					for _, refs := range match.MessageRefs {
 						// send a message per match
 						msg := interfaces.ClientTrackerMessage{
-							MessageType: interfaces.UserMessageTypeAssociation,
+							Type: sdkinterfaces.MessageTypeUserDefined,
 							Data: interfaces.Data{
+								Type: interfaces.UserMessageTypeAssociation,
 								Author: interfaces.Author{
 									Name:  user.Props["name"].(string),
 									Email: user.Props["email"].(string),
@@ -150,9 +152,11 @@ func (ch TrackerHandler) ProcessMessage(byData []byte) error {
 				for _, match := range tracker.Matches {
 					for _, refs := range match.InsightRefs {
 						// send a message per match
+
 						msg := interfaces.ClientTrackerMessage{
-							MessageType: interfaces.UserMessageTypeAssociation,
+							Type: sdkinterfaces.MessageTypeUserDefined,
 							Data: interfaces.Data{
+								Type: interfaces.UserMessageTypeAssociation,
 								Author: interfaces.Author{
 									Name:  user.Props["name"].(string),
 									Email: user.Props["email"].(string),

--- a/pkg/dataminer/instance/constants.go
+++ b/pkg/dataminer/instance/constants.go
@@ -15,6 +15,13 @@ const (
 	MessageTypeTeardownConversation string = "conversation_completed"
 )
 
+type ClientNotifyType int
+
+const (
+	ClientNotifyTypeWebSocket ClientNotifyType = iota
+	ClientNotifyTypeServerSendEvent
+)
+
 var (
 	// ErrInvalidInput required input was not found
 	ErrInvalidInput = errors.New("required input was not found")

--- a/pkg/dataminer/instance/types.go
+++ b/pkg/dataminer/instance/types.go
@@ -14,9 +14,13 @@ import (
 )
 
 type InstanceOptions struct {
+	// options
+	CrtFile    string
+	KeyFile    string
+	NotifyType ClientNotifyType
+
+	// housekeeping
 	ConversationId    string
-	CrtFile           string
-	KeyFile           string
 	ProxyBindAddress  string
 	NotifyBindAddress string
 	RedirectAddress   string

--- a/pkg/dataminer/routing/handler.go
+++ b/pkg/dataminer/routing/handler.go
@@ -955,9 +955,18 @@ func (mh *MessageHandler) TeardownConversation(tm *sdkinterfaces.TeardownMessage
 	return nil
 }
 
+// Not used
 func (mh *MessageHandler) UnhandledMessage(byMsg []byte) error {
 	klog.V(1).Infof("\n\n-------------------------------\n")
 	klog.V(1).Infof("UnhandledMessage:\n%v\n", string(byMsg))
+	klog.V(1).Infof("-------------------------------\n\n")
+	return nil
+}
+
+// Not used
+func (mh *MessageHandler) UserDefinedMessage(byMsg []byte) error {
+	klog.V(1).Infof("\n\n-------------------------------\n")
+	klog.V(1).Infof("UserDefinedMessage:\n%v\n", string(byMsg))
 	klog.V(1).Infof("-------------------------------\n\n")
 	return nil
 }

--- a/pkg/interfaces/types.go
+++ b/pkg/interfaces/types.go
@@ -22,18 +22,20 @@ type Message struct {
 	PreviousContent string `json:"previousContent,omitempty"`
 	PreviousMatch   string `json:"previousMatch,omitempty"`
 }
+
 type Data struct {
+	Type    string  `json:"type,omitempty"`
 	Author  Author  `json:"author,omitempty"`
 	Message Message `json:"message,omitempty"`
 }
 
 type ClientTrackerMessage struct {
-	MessageType string `json:"messageType,omitempty"`
-	Data        Data   `json:"data,omitempty"`
+	Type string `json:"type,omitempty"`
+	Data Data   `json:"data,omitempty"`
 }
 
 type ClientMessageType struct {
-	MessageType string `json:"messageType,omitempty"`
+	Type string `json:"type,omitempty"`
 }
 
 /*


### PR DESCRIPTION
## What this PR does / why we need it
<!--
Add a detailed explanation of what this PR does and why it is needed.
-->
This introduces a second method for sending user-defined or application-level messages back to the client (aka web browser UI) on the the existing websocket connection. This method will now be the default which supersedes the Server Send Message implementation.

## Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: #

## Describe testing done for PR
<!--
Example: I ran the application and it produced the desired output.
-->

## Special notes for your reviewer
<!--
Add any things that reviewers should be aware of as they review
your PR.

Example: Please verify how I handled foo aligns with overall plan.
-->
